### PR TITLE
Split workflow into 2 separate files

### DIFF
--- a/.github/workflows/sumo-ci.yml
+++ b/.github/workflows/sumo-ci.yml
@@ -1,11 +1,12 @@
 name: SUMO CI
 
-workflow_call:
-  inputs:
-    vampire_timeout:
-      description: 'How long vampire should run'
-      required: true
-      type: number
+on:
+  workflow_call:
+    inputs:
+      vampire_timeout:
+        description: 'How long vampire should run'
+        required: true
+        type: number
 
 env:
   DEFAULT_DOCKER_ACCOUNT: apease

--- a/.github/workflows/sumo-ci.yml
+++ b/.github/workflows/sumo-ci.yml
@@ -1,12 +1,12 @@
 name: SUMO CI
 
-on:
-  push:
-    branches: [ "master", "main" ]
-  pull_request:
-    branches: [ "master", "main" ]
-  schedule:
-    - cron:  '30 8 * * 6'
+workflow_call:
+  inputs:
+    vampire_timeout:
+      description: 'How long vampire should run'
+      required: true
+      type: number
+
 env:
   DEFAULT_DOCKER_ACCOUNT: apease
 
@@ -22,7 +22,7 @@ jobs:
           DOCKER_ACCOUNT: ${{ vars.DOCKER_ACCOUNT }}
         run: echo "image_account=${DOCKER_ACCOUNT:-$DEFAULT_DOCKER_ACCOUNT}" >> "$GITHUB_OUTPUT"
 
-  build:
+  build_sumo_tptp:
     runs-on: ubuntu-latest
     needs: derive_docker
     container:
@@ -31,15 +31,6 @@ jobs:
       SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
 
     steps:
-    - name: Set vampire timeout
-      run: |
-        case "$GITHUB_EVENT_NAME" in
-         schedule) VAMPIRE_TIMEOUT=10800 ;;
-                *) VAMPIRE_TIMEOUT=900 ;;
-        esac
-        echo "VAMPIRE_TIMEOUT=$VAMPIRE_TIMEOUT"
-        echo "VAMPIRE_TIMEOUT=$VAMPIRE_TIMEOUT" >> $GITHUB_ENV
-          
     - uses: actions/checkout@v3
       with:
         path: sumo
@@ -47,10 +38,8 @@ jobs:
     - name: Setup SigmaKEE
       env:
         ONTOLOGYPORTAL_GIT: ${{ github.workspace }}
-        VAMPIRE_TIMEOUT: ${{ env.VAMPIRE_TIMEOUT }}
       run: |
         echo "SIGMA_HOME: $SIGMA_HOME"
-        echo "VAMPIRE_TIMEOUT: $VAMPIRE_TIMEOUT"
         mkdir -p $SIGMA_HOME/KBs/WordNetMappings
         wget https://raw.githubusercontent.com/ontologyportal/sigmakee/master/config.xml
         cp ./config.xml $SIGMA_HOME/KBs
@@ -64,13 +53,32 @@ jobs:
     - name: Produce SUMO.tptp
       run: java -Xmx8g -classpath "/root/sigmakee/*" com.articulate.sigma.trans.SUMOKBtoTPTPKB
 
+    - name: Upload SUMO.tptp
+      uses: actions/upload-artifact@v3
+      with:
+        name: SUMO.tptp
+        path: $SIGMA_HOME/KBs/SUMO.tptp
+
+  run_vampire:
+    runs-on: ubuntu-latest
+    needs: [derive_docker,build_sumo_tptp]
+    container:
+      image: ${{ needs.derive_docker.outputs.image_account }}/sumo-ci:latest
+    env:
+      SIGMA_HOME: ${{ github.workspace }}/sigmakee-runtime
+
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: SUMO.tptp
+
     - name: Run vampire against SUMO.tptp
       env:
-        VAMPIRE_TIMEOUT: ${{ env.VAMPIRE_TIMEOUT }}
+        VAMPIRE_TIMEOUT: ${{ inputs.vampire_timeout }}
       run: |
-        ls -l $SIGMA_HOME/KBs/SUMO.tptp
+        ls -l .
         echo "VAMPIRE_TIMEOUT: $VAMPIRE_TIMEOUT"
-        /usr/local/bin/vampire --proof tptp -t $VAMPIRE_TIMEOUT $SIGMA_HOME/KBs/SUMO.tptp > vamp-out.txt || echo "Ignoring vampire exit code"
+        /usr/local/bin/vampire --proof tptp -t $VAMPIRE_TIMEOUT SUMO.tptp > vamp-out.txt || echo "Ignoring vampire exit code"
         mkdir -p $SIGMA_HOME/webapps/sigma/graph
         CATALINA_HOME=$SIGMA_HOME java -Xmx8g -classpath "/root/sigmakee/*" com.articulate.sigma.trans.TPTP3ProofProcessor -f vamp-out.txt
         cp $SIGMA_HOME/webapps/sigma/graph/proof.* .

--- a/.github/workflows/sumo-ci.yml
+++ b/.github/workflows/sumo-ci.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: SUMO.tptp
-        path: $SIGMA_HOME/KBs/SUMO.tptp
+        path: ${{ env.SIGMA_HOME }}/KBs/SUMO.tptp
 
   run_vampire:
     runs-on: ubuntu-latest

--- a/.github/workflows/sumo-dev-cycle.yml
+++ b/.github/workflows/sumo-dev-cycle.yml
@@ -1,0 +1,13 @@
+name: SUMO CI
+
+on:
+  push:
+    branches: [ "master", "main" ]
+  pull_request:
+    branches: [ "master", "main" ]
+
+jobs:
+   call-sumo-check-workflow:
+    uses: .github/workflows/sumo-ci.yml
+    with:
+      vampire_timeout: 900

--- a/.github/workflows/sumo-dev-cycle.yml
+++ b/.github/workflows/sumo-dev-cycle.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
    call-sumo-check-workflow:
-    uses: .github/workflows/sumo-ci.yml
+    uses: ./.github/workflows/sumo-ci.yml
     with:
       vampire_timeout: 900

--- a/.github/workflows/sumo-scheduled.yml
+++ b/.github/workflows/sumo-scheduled.yml
@@ -1,0 +1,12 @@
+name: SUMO CI
+
+on:
+  schedule:
+    - cron:  '30 8 * * 6'
+
+jobs:
+   call-sumo-check-workflow:
+    if: github.repository == 'ontologyportal/sumo'
+    uses: .github/workflows/sumo-ci.yml
+    with:
+      vampire_timeout: 10800

--- a/.github/workflows/sumo-scheduled.yml
+++ b/.github/workflows/sumo-scheduled.yml
@@ -7,6 +7,6 @@ on:
 jobs:
    call-sumo-check-workflow:
     if: github.repository == 'ontologyportal/sumo'
-    uses: .github/workflows/sumo-ci.yml
+    uses: ./.github/workflows/sumo-ci.yml
     with:
       vampire_timeout: 10800


### PR DESCRIPTION
To prevent batch job to run on forked repos guard is added which only runs workflow on ontologyportal
TPTP job extracted as well as it takes long time to build and it's good to be able to restart one step of workflow only.